### PR TITLE
Split beautifying into 2 settings

### DIFF
--- a/docs/topics/feed-exports.rst
+++ b/docs/topics/feed-exports.rst
@@ -267,22 +267,38 @@ If an exporter requires a fixed set of fields (this is the case for
 is empty or None, then Scrapy tries to infer field names from the
 exported data - currently it uses field names from the first item.
 
+.. setting:: FEED_EXPORT_BEAUTIFY
+
+FEED_EXPORT_BEAUTIFY
+--------------------
+
+Default: ``False``
+
+Pretty-print exported items.
+
+Currently used by :class:`~scrapy.exporters.JsonItemExporter`
+and :class:`~scrapy.exporters.XmlItemExporter`.
+
+If ``FEED_EXPORT_BEAUTIFY`` is set to ``False``, exporters supporting
+this option will write each item on a new line.
+This format remains human readable yet is compact enough.
+
+If ``FEED_EXPORT_BEAUTIFY`` is ``True``, then array elements and object
+members will be pretty-printed using :setting:`FEED_EXPORT_INDENT` spaces.
+This is more human readable but to the expense of extra whitespace characters.
+
 .. setting:: FEED_EXPORT_INDENT
 
 FEED_EXPORT_INDENT
 ------------------
 
-Default: ``0``
+Default: ``4``
 
-Amount of spaces used to indent the output on each level. If ``FEED_EXPORT_INDENT``
-is a non-negative integer, then array elements and object members will be pretty-printed
-with that indent level. An indent level of ``0`` (or negative) will put each item on a new line.
-``None`` selects the most compact representation.
-Alternatively, the ``compact`` and ``lines`` string constants are supported, translating
-to ``None`` and ``0`` respectively.
+Amount of spaces used to indent the output on each level.
+This setting is effective only if :setting:`FEED_EXPORT_INDENT` is ``True``.
 
 Currently used by :class:`~scrapy.exporters.JsonItemExporter`
-and :class:`~scrapy.exporters.XmlItemExporter`
+and :class:`~scrapy.exporters.XmlItemExporter`.
 
 .. setting:: FEED_STORE_EMPTY
 

--- a/scrapy/extensions/feedexport.py
+++ b/scrapy/extensions/feedexport.py
@@ -172,21 +172,8 @@ class FeedExporter(object):
         self.store_empty = settings.getbool('FEED_STORE_EMPTY')
         self._exporting = False
         self.export_fields = settings.getlist('FEED_EXPORT_FIELDS') or None
-        indent = settings.get('FEED_EXPORT_INDENT')
-        if indent is None or isinstance(indent, int):
-            self.indent = indent
-        elif isinstance(indent, six.string_types):
-            try:
-                self.indent = settings.getint('FEED_EXPORT_INDENT')
-            except ValueError:
-                indent = indent.lower().strip()
-                if indent == 'compact':
-                    self.indent = None
-                elif indent == 'lines':
-                    self.indent = 0
-        if not hasattr(self, 'indent'):
-            logger.info('Unsupported value for FEED_EXPORT_INDENT setting, using 0 ("lines") as default')
-            self.indent = 0
+        self.beautify = settings.getbool('FEED_EXPORT_BEAUTIFY')
+        self.indent = settings.getint('FEED_EXPORT_INDENT')
         uripar = settings['FEED_URI_PARAMS']
         self._uripar = load_object(uripar) if uripar else lambda x, y: None
 
@@ -203,7 +190,7 @@ class FeedExporter(object):
         storage = self._get_storage(uri)
         file = storage.open(spider)
         exporter = self._get_exporter(file, fields_to_export=self.export_fields,
-            encoding=self.export_encoding, indent=self.indent)
+            encoding=self.export_encoding, beautify=self.beautify, indent=self.indent)
         if self.store_empty:
             exporter.start_exporting()
             self._exporting = True

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -161,7 +161,8 @@ FEED_EXPORTERS_BASE = {
     'marshal': 'scrapy.exporters.MarshalItemExporter',
     'pickle': 'scrapy.exporters.PickleItemExporter',
 }
-FEED_EXPORT_INDENT = 0
+FEED_EXPORT_BEAUTIFY = False
+FEED_EXPORT_INDENT = 4
 
 FILES_STORE_S3_ACL = 'private'
 


### PR DESCRIPTION
Here's my suggestion based on [my comments](https://github.com/scrapy/scrapy/pull/2456#issuecomment-293632729).

In this, there are now 2 settings, `FEED_EXPORT_BEAUTIFY` and `FEED_EXPORT_INDENT`.

The XML exporter is also changed to add newlines after `<items>` and `<item>` elements, whatever beautifying setting is on. It's indeed less compact, but it make this closer to what the JSON exporter does.

JSON exporter also is reverted to `[` and `]` on their own line, and each JSON also on their own line.